### PR TITLE
feat: Initial support for module federation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "patternfly-seed",
+  "name": "mk-ui-frontend",
   "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,8 +1,10 @@
 {
-  "name": "patternfly-seed",
+  "name": "mk-ui-frontend",
+  "federatedModuleName": "mkUiFrontend",
   "version": "0.0.2",
   "description": "An open source build scaffolding utility for web apps.",
   "main": "server.js",
+  "port": "9000",
   "repository": "https://github.com/patternfly/patternfly-react-seed.git",
   "homepage": "https://patternfly-react-seed.surge.sh",
   "license": "MIT",

--- a/src/app/OpenshiftStreams/index.ts
+++ b/src/app/OpenshiftStreams/index.ts
@@ -1,0 +1,1 @@
+export * from './OpenshiftStreams';

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { App } from '@app/index';
+
+if (process.env.NODE_ENV !== "production") {
+  const config = {
+    rules: [
+      {
+        id: 'color-contrast',
+        enabled: false
+      }
+    ]
+  };
+  // eslint-disable-next-line @typescript-eslint/no-var-requires, no-undef
+  const axe = require("react-axe");
+  axe(React, ReactDOM, 1000, config);
+}
+
+ReactDOM.render(<App />, document.getElementById("root") as HTMLElement);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,19 +1,2 @@
-import React from "react";
-import ReactDOM from "react-dom";
-import { App } from '@app/index';
+import('./bootstrap');
 
-if (process.env.NODE_ENV !== "production") {
-  const config = {
-    rules: [
-      {
-        id: 'color-contrast',
-        enabled: false
-      }
-    ]
-  };
-  // eslint-disable-next-line @typescript-eslint/no-var-requires, no-undef
-  const axe = require("react-axe");
-  axe(React, ReactDOM, 1000, config);
-}
-
-ReactDOM.render(<App />, document.getElementById("root") as HTMLElement);

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,12 +1,16 @@
 const path = require('path');
 const { merge } = require("webpack-merge");
 const common = require("./webpack.common.js");
-const HOST = process.env.HOST || "0.0.0.0";
+const HOST = process.env.HOST || "localhost";
 const PORT = process.env.PORT || "9000";
 
 module.exports = merge(common('development'), {
   mode: "development",
   devtool: "eval-source-map",
+  output: {
+    // This must be set explicitly for module federation
+    publicPath: `http://${HOST}:${PORT}/`
+  },
   devServer: {
     contentBase: "./dist",
     host: HOST,

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -20,6 +20,9 @@ module.exports = merge(common('production'), {
       chunkFilename: '[name].bundle.css'
     })
   ],
+  output: {
+    publicPath: `http://TODO`
+  },
   module: {
     rules: [
       {


### PR DESCRIPTION
This allows us to import the OpenshiftStreams react component.

* Move port and module name to `package.json`
* Rename the app
* provide barrel export for OpenshiftStreams
* introduce the bootstrap indirection
* add module federation config to webpack.common.js
* explicitly set the `publicPath` in web pack (required by module
  federation)

Note that non-dev configuration is broken - this needs fixing in a 
later PR