### PR TITLE
[WIP] chore: make the federated module export default to work with React.lazy

### DIFF
--- a/src/app/OpenshiftStreams/OpenshiftStreamsFederated.tsx
+++ b/src/app/OpenshiftStreams/OpenshiftStreamsFederated.tsx
@@ -20,4 +20,4 @@ const OpenshiftStreamsFederated = ({ token }: OpenshiftStreamsFederatedProps) =>
   )
 };
 
-export { OpenshiftStreamsFederated };
+export default OpenshiftStreamsFederated;

--- a/src/app/OpenshiftStreams/index.ts
+++ b/src/app/OpenshiftStreams/index.ts
@@ -1,2 +1,1 @@
 export * from './OpenshiftStreams';
-export * from './OpenshiftStreamsFederated';

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -134,7 +134,7 @@ module.exports = (env, argv) => {
         name: federatedModuleName,
         filename: "remoteEntry.js",
         exposes: {
-          "./OpenshiftStreams": "./src/app/OpenshiftStreams",
+          "./OpenshiftStreams": "./src/app/OpenshiftStreams/OpenshiftStreamsFederated",
         },
         shared: {
           ...dependencies,


### PR DESCRIPTION
Please do not merge, this is part of https://github.com/bf2fc6cc711aee1a0c2a/mk-ui-host/pull/1