### PR TITLE
centering the loading spinner both vertically and horizontally

### DIFF
--- a/src/app/components/Loading/Loading.css
+++ b/src/app/components/Loading/Loading.css
@@ -1,8 +1,1 @@
 @import url('@redhat-cloud-services/frontend-components/components/Spinner.css');
-.pf-bullseye-comp {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    -ms-transform: translate(-50%, -50%);
-    transform: translate(-50%, -50%);
-}

--- a/src/app/components/Loading/Loading.tsx
+++ b/src/app/components/Loading/Loading.tsx
@@ -4,9 +4,7 @@ import { Spinner } from '@redhat-cloud-services/frontend-components';
 import './Loading.css';
 
 export const Loading: React.FunctionComponent = () => (
-  <PageSection>
-    <div className="pf-bullseye-comp">
-        <Spinner />
-    </div>
-  </PageSection>
+  <Bullseye>
+    <Spinner />
+  </Bullseye>
 );


### PR DESCRIPTION
Fix #64 
Make the loading spinner center aligned.
![image](https://user-images.githubusercontent.com/29524461/101784133-1d82c100-3b21-11eb-857b-c4d5ec4f2814.png)
