### PR TITLE
resolve the small bug related to cursor in delete option of table

### DIFF
--- a/src/app/components/StreamsTableView/StreamsTableView.tsx
+++ b/src/app/components/StreamsTableView/StreamsTableView.tsx
@@ -242,8 +242,16 @@ const StreamsTableView = ({
         title: t('connect_to_instance'),
         id: 'connect-instance',
         onClick: () => onViewConnection(originalData),
-      },
-      {
+      }
+    ];
+    if (isUserSameAsLoggedIn) {
+      resolver.push({
+        title: t('delete_instance'),
+        id: 'delete-instance',
+        onClick: () => isUserSameAsLoggedIn && onDelete(originalData),
+      });
+    } else {
+      resolver.push({
         title: t('delete_instance'),
         id: 'delete-instance',
         onClick: () => isUserSameAsLoggedIn && onDelete(originalData),
@@ -257,8 +265,8 @@ const StreamsTableView = ({
           pointerEvents: 'auto',
           cursor: 'default',
         },
-      },
-    ];
+      });
+    }
     return resolver;
   };
 


### PR DESCRIPTION
Fix #171 
Resolved this bug - When the user has the ability to delete their instance as in the case below, the cursor is the pointer rather than the grabbing hand like it should be for any button.