### PR TITLE
fix: make browser history and click work for instance

### DIFF
--- a/src/app/OpenshiftStreams/OpenshiftStreams.tsx
+++ b/src/app/OpenshiftStreams/OpenshiftStreams.tsx
@@ -27,6 +27,7 @@ import './OpenshiftStreams.css';
 
 export type OpenShiftStreamsProps = {
   onConnectToInstance: (data: KafkaRequest) => void;
+  getConnectToInstancePath: (data: KafkaRequest) => string;
 };
 
 type SelectedInstance = {
@@ -34,7 +35,7 @@ type SelectedInstance = {
   activeTab: 'Details' | 'Connection';
 };
 
-const OpenshiftStreams = ({ onConnectToInstance }: OpenShiftStreamsProps) => {
+const OpenshiftStreams = ({ onConnectToInstance, getConnectToInstancePath }: OpenShiftStreamsProps) => {
   const authContext = useContext(AuthContext);
   const { basePath } = useContext(ApiContext);
 
@@ -257,6 +258,7 @@ const OpenshiftStreams = ({ onConnectToInstance }: OpenShiftStreamsProps) => {
                   onViewConnection={onViewConnection}
                   onViewInstance={onViewInstance}
                   onConnectToInstance={onConnectToInstance}
+                  getConnectToInstancePath={getConnectToInstancePath}
                   refresh={refreshKafkas}
                   kafkaDataLoaded={kafkaDataLoaded}
                   onDelete={onDelete}

--- a/src/app/OpenshiftStreams/OpenshiftStreamsConnected.tsx
+++ b/src/app/OpenshiftStreams/OpenshiftStreamsConnected.tsx
@@ -6,13 +6,6 @@ import { ApiContext } from '@app/api/ApiContext';
 
 declare const __BASE_PATH__: string;
 
-const onConnectInstance = async (event: KafkaRequest) => {
-  if (event.id === undefined) {
-    throw new Error();
-  }
-  console.log(event.id);
-};
-
 export const OpenshiftStreamsConnected = () => {
   return (
     <ApiContext.Provider value={
@@ -21,7 +14,7 @@ export const OpenshiftStreamsConnected = () => {
       }
     }>
       <AlertProvider>
-        <OpenshiftStreams onConnectToInstance={onConnectInstance} />
+        <OpenshiftStreams onConnectToInstance={() => {}} getConnectToInstancePath={() => ""} />
       </AlertProvider>
     </ApiContext.Provider>
   );

--- a/src/app/OpenshiftStreams/OpenshiftStreamsFederated.tsx
+++ b/src/app/OpenshiftStreams/OpenshiftStreamsFederated.tsx
@@ -14,11 +14,12 @@ export type OpenshiftStreamsFederatedProps = {
   getToken: () => Promise<string>;
   getUsername: () => Promise<string>;
   onConnectToInstance: (data: KafkaRequest) => void;
+  getConnectToInstancePath: (data: KafkaRequest) => string;
   addAlert: (message: string, variant?: AlertVariant) => void;
   basePath: string;
 };
 
-const OpenshiftStreamsFederated = ({ getUsername, getToken, onConnectToInstance, addAlert, basePath }: OpenshiftStreamsFederatedProps) => {
+const OpenshiftStreamsFederated = ({ getUsername, getToken, onConnectToInstance,getConnectToInstancePath, addAlert, basePath }: OpenshiftStreamsFederatedProps) => {
 
   const authContext = {
     getToken,
@@ -39,7 +40,7 @@ const OpenshiftStreamsFederated = ({ getUsername, getToken, onConnectToInstance,
       }>
         <AlertContext.Provider value={alertContext}>
           <AuthContext.Provider value={authContext}>
-            <OpenshiftStreams onConnectToInstance={onConnectToInstance}></OpenshiftStreams>
+            <OpenshiftStreams onConnectToInstance={onConnectToInstance} getConnectToInstancePath={getConnectToInstancePath}></OpenshiftStreams>
           </AuthContext.Provider>
         </AlertContext.Provider>
       </ApiContext.Provider>

--- a/src/app/components/StreamsTableView/StreamsTableView.test.tsx
+++ b/src/app/components/StreamsTableView/StreamsTableView.test.tsx
@@ -60,6 +60,7 @@ describe('<StreamsTableView/>', () => {
     kafkaInstanceItems,
     onViewInstance: jest.fn(),
     onViewConnection: jest.fn(),
+    getOnConnectToInstancePath: jest.fn(),
     onConnectToInstance: jest.fn(),
     mainToggle: false,
     refresh: jest.fn(),

--- a/src/app/components/StreamsTableView/StreamsTableView.tsx
+++ b/src/app/components/StreamsTableView/StreamsTableView.tsx
@@ -56,6 +56,7 @@ export type StreamsTableProps = {
   onViewInstance: (instance: KafkaRequest) => void;
   onViewConnection: (instance: KafkaRequest) => void;
   onConnectToInstance: (data: KafkaRequest) => void;
+  getConnectToInstancePath: (data: KafkaRequest) => string;
   mainToggle: boolean;
   refresh: () => void;
   page: number;
@@ -106,6 +107,7 @@ const StreamsTableView = ({
   onViewInstance,
   onViewConnection,
   onConnectToInstance,
+  getConnectToInstancePath,
   refresh,
   createStreamsInstance,
   setCreateStreamsInstance,
@@ -331,7 +333,7 @@ const StreamsTableView = ({
         cells: [
           {
             title: (
-              <Link to="" onClick={() => onConnectToInstance(row as KafkaRequest)}>
+              <Link to={() => getConnectToInstancePath(row as KafkaRequest)} onClick={(e) => {e.preventDefault(); onConnectToInstance(row as KafkaRequest)}}>
                 {name}
               </Link>
             ),


### PR DESCRIPTION
* prevent the default click event (React can’t handle it due to module federation)
* pass in the URL to render in the link

Fixes #220