### PR TITLE
null load pf react styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4780,9 +4780,9 @@
       }
     },
     "@patternfly/patternfly": {
-      "version": "4.87.3",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.87.3.tgz",
-      "integrity": "sha512-hDNMPa7B1zKD8LWFZO4SS5hC/N+yvuci2sAn8HJd+EIbAvbMAUkRsyZ0/XO3BG3RVtpSlgq7q8x1pAHC/FTFuA=="
+      "version": "4.96.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.96.2.tgz",
+      "integrity": "sha512-nxXLyAGVYubXdJ8XuSPDuPBuUbuY1XPyYYzkIg6AmWp/bLA5Fs1kqX32F4djjGgR1eOteqRz478W/CE7Xi5E4A=="
     },
     "@patternfly/react-catalog-view-extension": {
       "version": "4.10.29",
@@ -4897,6 +4897,11 @@
         "tslib": "1.13.0"
       },
       "dependencies": {
+        "@patternfly/patternfly": {
+          "version": "4.87.3",
+          "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.87.3.tgz",
+          "integrity": "sha512-hDNMPa7B1zKD8LWFZO4SS5hC/N+yvuci2sAn8HJd+EIbAvbMAUkRsyZ0/XO3BG3RVtpSlgq7q8x1pAHC/FTFuA=="
+        },
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
@@ -19116,6 +19121,29 @@
       "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
       "requires": {
         "boolbase": "~1.0.0"
+      }
+    },
+    "null-loader": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/null-loader/-/null-loader-4.0.1.tgz",
+      "integrity": "sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        }
       }
     },
     "num2fraction": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "imagemin": "^7.0.0",
     "jest": "^26.5.3",
     "mini-css-extract-plugin": "^1.3.9",
+    "null-loader": "^4.0.1",
     "optimize-css-assets-webpack-plugin": "^5.0.4",
     "prettier": "^2.2.1",
     "prop-types": "^15.6.1",
@@ -86,6 +87,7 @@
   },
   "dependencies": {
     "@cloudmosaic/quickstarts": "0.0.19",
+    "@patternfly/patternfly": "^4.96.2",
     "@patternfly/react-core": "^4.97.2",
     "@patternfly/react-icons": "^4.9.2",
     "@patternfly/react-styles": "^4.8.2",

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import '@patternfly/react-core/dist/styles/base.css';
+import "@patternfly/patternfly/patternfly.min.css";
 import { BrowserRouter as Router } from 'react-router-dom';
 import { AppLayout } from '@app/AppLayout/AppLayout';
 import { AppRoutes } from '@app/routes';

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -36,13 +36,15 @@ module.exports = (env, argv) => {
           sideEffects: true
         },
         {
+          test: /\.css$/,
+          include: stylesheet => stylesheet.includes('@patternfly/react-styles/css/'),
+          use: ["null-loader"]
+        },
+        {
           test: /\.(svg|ttf|eot|woff|woff2)$/,
           // only process modules with this loader
           // if they live under a 'fonts' or 'pficon' directory
           include: [
-            path.resolve(__dirname, 'node_modules/patternfly/dist/fonts'),
-            path.resolve(__dirname, 'node_modules/@patternfly/react-core/dist/styles/assets/fonts'),
-            path.resolve(__dirname, 'node_modules/@patternfly/react-core/dist/styles/assets/pficon'),
             path.resolve(__dirname, 'node_modules/@patternfly/patternfly/assets/fonts'),
             path.resolve(__dirname, 'node_modules/@patternfly/patternfly/assets/pficon')
           ],
@@ -99,13 +101,7 @@ module.exports = (env, argv) => {
           test: /\.(jpg|jpeg|png|gif)$/i,
           include: [
             path.resolve(__dirname, 'src'),
-            path.resolve(__dirname, 'node_modules/patternfly'),
-            path.resolve(__dirname, 'node_modules/@patternfly/patternfly/assets/images'),
-            path.resolve(__dirname, 'node_modules/@patternfly/react-styles/css/assets/images'),
-            path.resolve(__dirname, 'node_modules/@patternfly/react-core/dist/styles/assets/images'),
-            path.resolve(__dirname, 'node_modules/@patternfly/react-core/node_modules/@patternfly/react-styles/css/assets/images'),
-            path.resolve(__dirname, 'node_modules/@patternfly/react-table/node_modules/@patternfly/react-styles/css/assets/images'),
-            path.resolve(__dirname, 'node_modules/@patternfly/react-inline-edit-extension/node_modules/@patternfly/react-styles/css/assets/images')
+            path.resolve(__dirname, 'node_modules/@patternfly/patternfly/assets/images')
           ],
           use: [
             {


### PR DESCRIPTION
See also:
https://github.com/patternfly/patternfly-react/wiki/Disabling-Style-Injection-with-Webpack

This way we can have a single PF css loaded and not run into weird issues of different package's PF styles overriding each other