### PR TITLE
fix: Remove toggle icon from Toolbar in Service Accounts UI

### DIFF
--- a/src/app/common/MASToolbar/MASToolbar.tsx
+++ b/src/app/common/MASToolbar/MASToolbar.tsx
@@ -14,7 +14,7 @@ export type ToolbarItemProps = Omit<PFToolbarItemProps, 'children'> & {
 };
 export type MASToolbarProps = {
   toolbarProps: Omit<ToolbarProps, 'children' | 'ref'>;
-  toggleGroupProps: Omit<ToolbarToggleGroupProps, 'children'>;
+  toggleGroupProps?: Omit<ToolbarToggleGroupProps, 'children'>;
   toggleGroupItems?: any;
   toolbarItems?: ToolbarItemProps[];
 };
@@ -26,7 +26,7 @@ const MASToolbar: React.FunctionComponent<MASToolbarProps> = ({
   toggleGroupItems,
 }) => {
   const { id, clearAllFilters, collapseListedFiltersBreakpoint = 'md', inset, ...restToolbarProps } = toolbarProps;
-  const { toggleIcon, breakpoint = 'md', ...toolbarToggleGroupProps } = toggleGroupProps;
+
   return (
     <>
       <Toolbar
@@ -37,9 +37,11 @@ const MASToolbar: React.FunctionComponent<MASToolbarProps> = ({
         {...restToolbarProps}
       >
         <ToolbarContent>
-          <ToolbarToggleGroup toggleIcon={toggleIcon} breakpoint={breakpoint} {...toolbarToggleGroupProps}>
-            {toggleGroupItems}
-          </ToolbarToggleGroup>
+          { toggleGroupProps && (
+            <ToolbarToggleGroup toggleIcon={toggleGroupProps.toggleIcon} breakpoint='md' {...toggleGroupProps}>
+              {toggleGroupItems}
+            </ToolbarToggleGroup>
+          )}
           {toolbarItems?.map((toolbarItem, index) => {
             const { key = 'mas', variant, className, id, alignment, item, ...restItemProps } = toolbarItem;
             return (

--- a/src/app/modules/ServiceAccounts/components/ServiceAccountsTableView/ServiceAccountsToolbar.tsx
+++ b/src/app/modules/ServiceAccounts/components/ServiceAccountsTableView/ServiceAccountsToolbar.tsx
@@ -352,8 +352,6 @@ const ServiceAccountsToolbar: React.FC<ServiceAccountsToolbarProps> = ({
         collapseListedFiltersBreakpoint: 'md',
         inset: { lg: 'insetLg' },
       }}
-      toggleGroupProps={{ toggleIcon: <FilterIcon />, breakpoint: 'md' }}
-      // toggleGroupItems={toggleGroupItems}
       toolbarItems={toolbarItems}
     />
   );


### PR DESCRIPTION
closes #416 
Since we don't have a toolbar, we only have a Create button, there is no need to keep the Toggle button still in the UI. Also it is causing some weird spacing issues.