### PR TITLE
Fixed run time issue for appendTo modal

### DIFF
--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -145,7 +145,7 @@ const getFormattedDate = (date: string | Date, translatePostfix: string) => {
   return formatDistance(date, new Date()) + ' ' + translatePostfix;
 }
 
-const getModalAppendTo = () => document.querySelector('#qs-content') as HTMLElement || document.querySelector("#root");
+const getModalAppendTo = () => document.querySelector('#qs-content') as HTMLElement || document.body;
 
 export {
   accessibleRouteChangeHandler,


### PR DESCRIPTION
Previous PR #422 is throwing run time error. 

This is happening due to not available id `#qs-content` in kas-ui . It will available when we will run host-app but need to run kas-ui independently. 

Fix https://github.com/bf2fc6cc711aee1a0c2a/kas-ui/issues/426


![image](https://user-images.githubusercontent.com/11775081/114986530-bc457280-9eb1-11eb-8fc1-83e43c9342c3.png)
