### PR TITLE
Fix vertical label on instance list

### DIFF
--- a/src/app/common/MASTable/CustomRowWrapper.css
+++ b/src/app/common/MASTable/CustomRowWrapper.css
@@ -19,7 +19,7 @@
   margin-bottom: var(--pf-global--spacer--xs); /* Makes bottom box shadow visible */
 }
 
-@media screen and (min-width: 768px) {
+@media screen and (min-width: 769px) {
   .pf-c-table-row__item td:first-child::before {
     position: absolute;
     top: var(--pf-c-table-row__item--before--Top);


### PR DESCRIPTION
On the ipad only, the "Name" label was showing vertically (wrapping to one character per line). This appears to have been an interaction between max-width media queries on PatternFly and the min-width media query here. Adjusting by one pixel fixed the problem.

NOTE: I actually believe that this CSS file can be removed completely, as Patternfly now supports the "hoverable and selectable" table, however, I'm proposing this change for now because I don't know the code well enough to know if something is missing without it. @christiemolloy 

![image](https://user-images.githubusercontent.com/19825616/115428461-6a159180-a1d0-11eb-9765-db0818540172.png)
