### PR TITLE
chore: add grouping for bf2

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,14 +11,14 @@
   "major": {
     "automerge": false
   },
-  "ignorePaths": [
-    "**/node_modules/**",
-    "**/__mocks__/**"
-  ],
   "packageRules": [
     {
       "matchPackagePatterns": ["^@rhoas"],
       "groupName": "RHOAS SDK packages"
+    },
+    {
+      "matchPackagePatterns": ["^@bf2"],
+      "groupName": "Shared components packages"
     }
   ]
 }


### PR DESCRIPTION
Our approach is to fastrack and automate merges. 
Since there is some outstanding work in kas-ui for testing and typescript checks for the moment both SDK's and Shared components will be requiring separate merge - but they need to be separated from ther packages