### PR TITLE
chore: configure automerge rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,18 +7,20 @@
    "ignoreDeps": [
     "keycloak-js"
   ],
-  "automerge": false,
+  "automerge": true,
   "major": {
     "automerge": false
   },
   "packageRules": [
     {
       "matchPackagePatterns": ["^@rhoas"],
-      "groupName": "RHOAS SDK packages"
+      "groupName": "RHOAS SDK packages",
+      "automerge": false,
     },
     {
       "matchPackagePatterns": ["^@bf2"],
-      "groupName": "Shared components packages"
+      "groupName": "Shared components packages",
+      "automerge": true,
     }
   ]
 }


### PR DESCRIPTION
TL;DR - If you doing active development on the repository it is best to turn on repository minor versions dependency autoupdate:
https://github.com/bf2fc6cc711aee1a0c2a/kas-ui/blob/main/renovate.json#L10
Let's have policy/reminder to check major updates and npm audit before major deployments as well.

Long

It looks like we have dependency updates on all repositories setup.
While depdendencies are pushed instantly we still need to be vigilant in merging those so they do not pile up.
Instead of looking to put some strategies for entire team I think it is best to give recommendations and let team leads to apply proper paths:

- Use autoupdates for repositories that we work on daily or have automation covered - if something breaks we will know about it 
- For UI setup separate group for patternfly as this is the dependency that is the most risky and can cause some unexpected glitches in random parts of the UI
- Teams should pick number of persons responsible for package updates
- Our package updates are not security updates - despite having all packages up to date we still need to regularly run `npm audit` before pushing to production. 