### PR TITLE
Fix  css for toggle group in create instance modal

### DIFF
--- a/src/app/modules/OpenshiftStreams/dialogs/CreateInstance/CreateInstance.css
+++ b/src/app/modules/OpenshiftStreams/dialogs/CreateInstance/CreateInstance.css
@@ -9,3 +9,7 @@
 .mk--create-instance-modal__sidebar--content dt {
   font-size: var(--pf-global--FontSize--sm);
 }
+
+.pf-c-toggle-group__button.pf-m-selected {
+	--pf-c-toggle-group__button--Color: 
+}

--- a/src/app/modules/OpenshiftStreams/dialogs/CreateInstance/CreateInstance.tsx
+++ b/src/app/modules/OpenshiftStreams/dialogs/CreateInstance/CreateInstance.tsx
@@ -313,7 +313,10 @@ const CreateInstance: React.FunctionComponent = () => {
           </FormSelect>
         </FormGroup>
         <FormGroup label={t('availabilty_zones')} fieldId="availability-zones">
-          <ToggleGroup aria-label={t('availability_zone_selection')}>
+          <ToggleGroup
+            className=".pf-c-toggle-group__button.pf-m-selected"
+            aria-label={t('availability_zone_selection')}
+          >
             <Tooltip content={t('kafkaInstance.availabilty_zones_tooltip_message')}>
               <ToggleGroupItem
                 text={t('single')}


### PR DESCRIPTION
Some extra css was making the text of selected item hard to read.