### PR TITLE
update modal appendTo target

### DIFF
--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -139,7 +139,8 @@ const getFormattedDate = (date: string | Date, translatePostfix: string): string
   return formatDistance(date, new Date()) + ' ' + translatePostfix;
 };
 
-const getModalAppendTo = (): HTMLElement => (document.querySelector('#qs-content') as HTMLElement) || document.body;
+const getModalAppendTo = (): HTMLElement =>
+  (document.getElementById('chrome-app-render-root') as HTMLElement) || document.body;
 
 const isMobileTablet = (): boolean => {
   let check = false;


### PR DESCRIPTION
So that when a quick start is open and the modal and backdrop is rendered, the user can still interact with the quick start.

Note: Will also create a PatternFly PR so that the backdrop position can be changed from the current `fixed` value to `absolute`, so that the modal is centered on its parent width, and not the entire viewport. It's not a blocker though.