### PR TITLE
fix(toolbar): remove extra style, add missing tag

### DIFF
--- a/src/app/common/MASToolbar/MASToolbar.test.tsx
+++ b/src/app/common/MASToolbar/MASToolbar.test.tsx
@@ -73,7 +73,7 @@ describe('<MASToolbar/>', () => {
           categoryName={'Name'}
         >
           <ToolbarItem>
-            <InputGroup className='mk--filter-instances__toolbar--text-input'>
+            <InputGroup>
               <TextInput
                 name='name'
                 id='filterText'

--- a/src/app/modules/OpenshiftStreams/components/StreamsTableView/StreamsToolbar.css
+++ b/src/app/modules/OpenshiftStreams/components/StreamsTableView/StreamsToolbar.css
@@ -1,7 +1,3 @@
-.mk--filter-instances__toolbar--text-input {
-  min-width: max-content;
-}
-
 .mk--filter-instances__toolbar--select--type-ahead
   .pf-c-select__toggle.pf-m-typeahead {
   width: 230px;

--- a/src/app/modules/OpenshiftStreams/components/StreamsTableView/StreamsToolbar.tsx
+++ b/src/app/modules/OpenshiftStreams/components/StreamsTableView/StreamsToolbar.tsx
@@ -12,6 +12,7 @@ import {
   ToolbarChip,
   ToolbarFilter,
   ToolbarGroup,
+  ToolbarItem,
   Tooltip,
   ValidatedOptions,
 } from '@patternfly/react-core';
@@ -403,24 +404,26 @@ const StreamsToolbar: React.FunctionComponent<StreamsToolbarProps> = ({
   const toggleGroupItems = (
     <>
       <ToolbarGroup variant='filter-group'>
-        <Select
-          variant={SelectVariant.single}
-          aria-label='Select filter'
-          onToggle={onFilterToggle}
-          selections={filterSelected}
-          isOpen={isFilterExpanded}
-          onSelect={onChangeSelect}
-        >
-          {mainFilterOptions.map((option, index) => (
-            <SelectOption
-              isDisabled={option.disabled}
-              key={index}
-              value={option.value}
-            >
-              {option.label}
-            </SelectOption>
-          ))}
-        </Select>
+        <ToolbarItem>
+          <Select
+            variant={SelectVariant.single}
+            aria-label='Select filter'
+            onToggle={onFilterToggle}
+            selections={filterSelected}
+            isOpen={isFilterExpanded}
+            onSelect={onChangeSelect}
+          >
+            {mainFilterOptions.map((option, index) => (
+              <SelectOption
+                isDisabled={option.disabled}
+                key={index}
+                value={option.value}
+              >
+                {option.label}
+              </SelectOption>
+            ))}
+          </Select>
+        </ToolbarItem>
         <ToolbarFilter
           chips={getSelectionForFilter('name')}
           deleteChip={(_category, chip) => onDeleteChip('name', chip)}
@@ -429,7 +432,7 @@ const StreamsToolbar: React.FunctionComponent<StreamsToolbarProps> = ({
           showToolbarItem={filterSelected?.toLowerCase() === 'name'}
         >
           {filterSelected?.toLowerCase() === 'name' && (
-            <InputGroup className='mk--filter-instances__toolbar--text-input'>
+            <InputGroup>
               <TextInput
                 name='name'
                 id='filterText'
@@ -568,7 +571,7 @@ const StreamsToolbar: React.FunctionComponent<StreamsToolbarProps> = ({
           showToolbarItem={filterSelected?.toLowerCase() === 'owner'}
         >
           {filterSelected.toLowerCase() === 'owner' && (
-            <InputGroup className='mk--filter-instances__toolbar--text-input'>
+            <InputGroup>
               <TextInput
                 name='owner'
                 id='filterOwners'

--- a/src/app/modules/ServiceAccounts/components/ServiceAccountsTableView/ServiceAccountsToolbar.tsx
+++ b/src/app/modules/ServiceAccounts/components/ServiceAccountsTableView/ServiceAccountsToolbar.tsx
@@ -261,7 +261,7 @@ const ServiceAccountsToolbar: React.FC<ServiceAccountsToolbarProps> = ({
         >
           {filterSelected?.toLowerCase() === 'name' && (
             <ToolbarItem>
-              <InputGroup className='mk--filter-instances__toolbar--text-input'>
+              <InputGroup>
                 <TextInput
                   name='name'
                   id='name-input'
@@ -305,7 +305,7 @@ const ServiceAccountsToolbar: React.FC<ServiceAccountsToolbarProps> = ({
         >
           {filterSelected?.toLowerCase() === 'owner' && (
             <ToolbarItem>
-              <InputGroup className='mk--filter-instances__toolbar--text-input'>
+              <InputGroup>
                 <TextInput
                   name='owner'
                   id='owner-input'


### PR DESCRIPTION
This fixes a problem in Safari where some of the toolbar filter items overlapped. The fix was to add a missing <ToolbarItem> around the select element, and then remove the unneeded CSS class `mk--filter-instances__toolbar--text-input`. This class was also used in the service accounts toolbar, which I cannot verify.

Before in Safari:
![image](https://user-images.githubusercontent.com/19825616/139282894-3d5c8fe5-1336-48fe-b83c-0be49ac438a8.png)

After in Safari:
![image](https://user-images.githubusercontent.com/19825616/139283057-a934480e-c7a9-43e7-bd16-c14cab8c9d54.png)

In Firefox:
![image](https://user-images.githubusercontent.com/19825616/139283187-af8ba9f1-1a24-4211-9542-c0b0dcf85c5b.png)

In Chrome:
![image](https://user-images.githubusercontent.com/19825616/139283286-48378737-e581-442c-9e77-c07670fd230c.png)

Mobile view:
![image](https://user-images.githubusercontent.com/19825616/139287276-fcb1a61a-7c43-4c63-91e9-a0f46165fbc8.png)
