### PR TITLE
fix: add OUIA id to create kafka modal

### DIFF
--- a/src/app/modules/OpenshiftStreams/dialogs/CreateInstance/CreateInstance.tsx
+++ b/src/app/modules/OpenshiftStreams/dialogs/CreateInstance/CreateInstance.tsx
@@ -245,6 +245,7 @@ const CreateInstance: React.FunctionComponent<
       isOpen={true}
       onClose={handleModalToggle}
       appendTo={getModalAppendTo}
+      ouiaId='modal-create-kafka'
       actions={[
         <Button
           key='submit'


### PR DESCRIPTION
Based on the updates of the design input in the Miro board here: https://miro.com/app/board/uXjVOeGbzSM=/?utm_source=notification&utm_medium=email&utm_campaign=daily-updates&utm_content=go-to-board, add a new `ouiaId` to the modal.