### PR TITLE
Feat. Replace static duration message with dynamic expiration message of kafka instance

### DIFF
--- a/src/app/modules/InstanceDrawer/DetailsTab.tsx
+++ b/src/app/modules/InstanceDrawer/DetailsTab.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import {
+  Alert,
   TextContent,
   TextList,
   TextListItem,
@@ -11,6 +12,7 @@ import localizedFormat from 'dayjs/plugin/localizedFormat';
 import dayjs from 'dayjs';
 import { KafkaRequest } from '@rhoas/kafka-management-sdk';
 import { useInstanceDrawer } from '@app/modules/InstanceDrawer/contexts/InstanceDrawerContext';
+import { getTimeLeft } from '@app/utils';
 
 export const DetailsTab: React.FunctionComponent = () => {
   const { instanceDrawerInstance } = useInstanceDrawer();
@@ -25,9 +27,22 @@ export const DetailsTab: React.FunctionComponent = () => {
         <TextListItem component={TextListItemVariants.dd}>{value}</TextListItem>
       </>
     );
+  const hours = created_at ? getTimeLeft(created_at, 'hours') : 48;
 
   return (
     <div className='mas--details__drawer--tab-content'>
+      <Alert
+        variant={
+          hours >= 24 ? 'info' : hours < 24 && hours >= 5 ? 'warning' : 'danger'
+        }
+        title={t('will_expire_in', {
+          time: created_at ? getTimeLeft(created_at) : '',
+        })}
+        aria-live='polite'
+        isInline
+        className='pf-u-mb-lg'
+      />
+
       <TextContent>
         <TextList component={TextListVariants.dl}>
           {renderTextListItem(t('cloud_provider'), t('amazon_web_services'))}

--- a/src/app/modules/OpenshiftStreams/components/StreamsTable/StreamsTable.tsx
+++ b/src/app/modules/OpenshiftStreams/components/StreamsTable/StreamsTable.tsx
@@ -12,6 +12,7 @@ import {
 import { KafkaRequest } from '@rhoas/kafka-management-sdk';
 import {
   getFormattedDate,
+  getTimeLeft,
   getLoadingRowsCount,
   getSkeletonForRows,
   InstanceStatus,
@@ -170,7 +171,10 @@ export const StreamsTable: React.FunctionComponent<StreamsTableProps> = ({
               <>
                 {getFormattedDate(created_at, t('ago'))}
                 <br />
-                {instance_type === InstanceType?.eval && '48 hours duration'}
+                {instance_type === InstanceType?.eval &&
+                  t('expires_in', {
+                    time: created_at ? getTimeLeft(created_at) : '',
+                  })}
               </>
             ),
           },

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -159,6 +159,32 @@ const getFormattedDate = (
   return formatDistance(date, new Date()) + ' ' + translatePostfix;
 };
 
+const getTimeLeft = (date: string | Date, kind?: string): string | number => {
+  date = typeof date === 'string' ? new Date(date) : date;
+  const timeOfExpiry = new Date(date);
+  timeOfExpiry.setDate(timeOfExpiry.getDate() + 2);
+  const currentDate = new Date();
+  const timeLeft = timeOfExpiry.getTime() - currentDate.getTime();
+  const hours = Math.floor(timeLeft / (60 * 60 * 1000));
+  const minutes = Math.floor(
+    (timeLeft - hours * (60 * 60 * 1000)) / ((60 * 60 * 1000) / 60)
+  );
+  if (kind == 'hours') return hours;
+  else if (hours == 0)
+    return minutes + ' ' + (minutes > 1 ? 'minutes' : 'minute');
+  else if (minutes == 0) return hours + ' ' + (hours > 1 ? 'hours' : 'hour');
+  else
+    return (
+      hours +
+      ' ' +
+      (hours > 1 ? 'hours' : 'hour') +
+      ' ' +
+      minutes +
+      ' ' +
+      (minutes > 1 ? 'minutes' : 'minute')
+    );
+};
+
 const getModalAppendTo = (): HTMLElement =>
   (document.getElementById('chrome-app-render-root') as HTMLElement) ||
   document.body;
@@ -218,6 +244,7 @@ export {
   MAX_SERVICE_ACCOUNT_NAME_LENGTH,
   sortValues,
   getFormattedDate,
+  getTimeLeft,
   getModalAppendTo,
   isMobileTablet,
   getSkeletonForRows,


### PR DESCRIPTION
Add time left before expiry of kafka instance to instance table and details tab in the drawer
[Link]( https://docs.google.com/presentation/d/1qi9lb_Oph8how4wqZS0Bgyr7Fr-yY4PwEnqBdYXE2MQ/edit#slide=id.ge61a5828d5_0_168) to the design docs
