### PR TITLE
Add backward compatibility for instanceType

### DIFF
--- a/src/app/modules/OpenshiftStreams/components/StreamsTable/StreamsTable.tsx
+++ b/src/app/modules/OpenshiftStreams/components/StreamsTable/StreamsTable.tsx
@@ -172,7 +172,7 @@ export const StreamsTable: FunctionComponent<StreamsTableProps> = ({
               <>
                 {getFormattedDate(created_at, t("ago"))}
                 <br />
-                {instance_type === InstanceType?.eval && (
+                {instance_type === InstanceType?.developer && (
                   <Trans
                     i18nKey="common.expires_in"
                     ns={["kasTemporaryFixMe"]}

--- a/src/app/modules/OpenshiftStreams/components/StreamsTable/StreamsTable.tsx
+++ b/src/app/modules/OpenshiftStreams/components/StreamsTable/StreamsTable.tsx
@@ -172,21 +172,21 @@ export const StreamsTable: FunctionComponent<StreamsTableProps> = ({
               <>
                 {getFormattedDate(created_at, t("ago"))}
                 <br />
-                {instance_type === InstanceType?.developer ||
-                  (instance_type === InstanceType?.eval && (
-                    <Trans
-                      i18nKey="common.expires_in"
-                      ns={["kasTemporaryFixMe"]}
-                      components={{
-                        time: (
-                          <FormatDate
-                            date={add(new Date(created_at), { days: 2 })}
-                            format="expiration"
-                          />
-                        ),
-                      }}
-                    />
-                  ))}
+                {(instance_type === InstanceType?.developer ||
+                  instance_type === InstanceType?.eval) && (
+                  <Trans
+                    i18nKey="common.expires_in"
+                    ns={["kasTemporaryFixMe"]}
+                    components={{
+                      time: (
+                        <FormatDate
+                          date={add(new Date(created_at), { days: 2 })}
+                          format="expiration"
+                        />
+                      ),
+                    }}
+                  />
+                )}
               </>
             ),
           },

--- a/src/app/modules/OpenshiftStreams/components/StreamsTable/StreamsTable.tsx
+++ b/src/app/modules/OpenshiftStreams/components/StreamsTable/StreamsTable.tsx
@@ -172,20 +172,21 @@ export const StreamsTable: FunctionComponent<StreamsTableProps> = ({
               <>
                 {getFormattedDate(created_at, t("ago"))}
                 <br />
-                {instance_type === InstanceType?.developer && (
-                  <Trans
-                    i18nKey="common.expires_in"
-                    ns={["kasTemporaryFixMe"]}
-                    components={{
-                      time: (
-                        <FormatDate
-                          date={add(new Date(created_at), { days: 2 })}
-                          format="expiration"
-                        />
-                      ),
-                    }}
-                  />
-                )}
+                {instance_type === InstanceType?.developer ||
+                  (instance_type === InstanceType?.eval && (
+                    <Trans
+                      i18nKey="common.expires_in"
+                      ns={["kasTemporaryFixMe"]}
+                      components={{
+                        time: (
+                          <FormatDate
+                            date={add(new Date(created_at), { days: 2 })}
+                            format="expiration"
+                          />
+                        ),
+                      }}
+                    />
+                  ))}
               </>
             ),
           },

--- a/src/app/modules/OpenshiftStreams/dialogs/CreateInstance/api.ts
+++ b/src/app/modules/OpenshiftStreams/dialogs/CreateInstance/api.ts
@@ -69,13 +69,8 @@ export const useAvailableProvidersAndDefault = () => {
     ia: InstanceAvailability
   ): Promise<Regions> => {
     const instance_type =
-      ia === "quota" ? InstanceType.standard : InstanceType.eval;
-    const res = await apisService.getCloudProviderRegions(
-      id,
-      undefined,
-      undefined,
-      InstanceType.eval
-    );
+      ia === "quota" ? InstanceType.standard : InstanceType.developer;
+    const res = await apisService.getCloudProviderRegions(id);
 
     return (res.data.items || [])
       .filter(
@@ -144,7 +139,7 @@ export const useAvailableProvidersAndDefault = () => {
       const res = await apisService.getKafkas("", "", "", filter);
       if (res.data.items) {
         return res.data.items.some(
-          (k) => k?.instance_type === InstanceType?.eval
+          (k) => k?.instance_type === InstanceType?.developer
         );
       }
     } catch (e) {

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -29,6 +29,7 @@ enum InstanceStatus {
 enum InstanceType {
   eval = "eval",
   standard = "standard",
+  developer = "developer",
 }
 
 const cloudProviderOptions: KeyValueOptions[] = [


### PR DESCRIPTION
Backend code is different on stage and prod. So need backward compatibility for instanceType in UI so that It should work fine on stage and prod.

on stage instancetype is `developer` and on prod instanceType is `eval`

Fixes:
1. Create kafka modal issue
2. Wrong trial message for standard kafka 
3.  Double alert message and wrong trial message for standard kafka
4. 
https://issues.redhat.com/browse/MGDSTRM-8360