### PR TITLE
chore: fix admin_server_url undefined issue

### DIFF
--- a/src/app/modules/InstanceDrawer/ConnectionTab.tsx
+++ b/src/app/modules/InstanceDrawer/ConnectionTab.tsx
@@ -11,7 +11,7 @@ export type ConnectionTabProps = {
   isKafkaPending?: boolean;
   tokenEndPointUrl: string;
   instanceId: string | undefined;
-  adminServerUrl: string;
+  adminServerUrl: string | undefined;
 };
 
 export const ConnectionTab: FC<ConnectionTabProps> = ({

--- a/src/app/modules/InstanceDrawer/InstanceDrawerContent.tsx
+++ b/src/app/modules/InstanceDrawer/InstanceDrawerContent.tsx
@@ -31,7 +31,7 @@ export const InstanceDrawerContent: FunctionComponent<
 
   const getAdminServerUrl = () => {
     const { admin_api_server_url } = instance;
-    return `${admin_api_server_url}/openapi`;
+    return admin_api_server_url ? `${admin_api_server_url}/openapi` : undefined;
   };
 
   const isKafkaPending =


### PR DESCRIPTION
Admin server URL will be undefined when the Kafka instance creation is in progress, adding skeleton when the Admin server url is undefined 

https://github.com/redhat-developer/app-services-ui-components/pull/476/

**Before**
![image (4)](https://user-images.githubusercontent.com/53568062/181502866-6049f571-7f1a-429d-ab85-beebf7152be2.png)

**After**
![image](https://user-images.githubusercontent.com/53568062/181503291-127c99cf-9c06-4965-bd33-5da7891b7ede.png)



 